### PR TITLE
Fix issues

### DIFF
--- a/fourofour_3d_gen/blender_manifest.toml
+++ b/fourofour_3d_gen/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "fourofour_3d_gen"
-version = "0.14.0"
+version = "0.14.1"
 name = "404 3D Generator"
 tagline = "404 3D Generator Extension"
 maintainer = "Ruben Hohndorf <ruben@atlas.design>"
@@ -10,9 +10,7 @@ type = "add-on"
 website = "https://github.com/404-Repo/three-gen-blender-plugin"
 tags = ["3D View"]
 blender_version_min = "4.5.0"
-license = [
-  "SPDX:GPL-3.0-or-later",
-]
+license = ["SPDX:GPL-3.0-or-later"]
 
 wheels = [
   "./wheels/annotated_types-0.7.0-py3-none-any.whl",
@@ -36,4 +34,3 @@ wheels = [
 [permissions]
 network = "Access model generation API"
 files = "Load PLY file from disk"
-

--- a/fourofour_3d_gen/gateway/gateway_api.py
+++ b/fourofour_3d_gen/gateway/gateway_api.py
@@ -46,7 +46,7 @@ class GatewayApi:
             url = self._construct_url(host=self._gateway_url, route=GatewayRoutes.ADD_TASK)
             model = "404-3dgs" if obj_type == "3DGS" else "404-mesh"
             print(text_prompt)
-            payload = {"prompt": text_prompt, "model": model}
+            payload = {"prompt": text_prompt, "model": model, "seed": seed}
             headers = {"x-api-key": self._gateway_api_key, "x-client-origin": "blender" }
             response = self._http_client.post(url=url, json=payload, headers=headers)
             response.raise_for_status()
@@ -67,7 +67,12 @@ class GatewayApi:
                 files = {"image": (os.path.basename(temp_path), f, "image/png")}
                 model = "404-3dgs" if obj_type == "3DGS" else "404-mesh"
                 headers = {"x-api-key": self._gateway_api_key, "x-client-origin": "blender" }
-                response = self._http_client.post(url=url, files=files, data={"model": model}, headers=headers)
+                response = self._http_client.post(
+                    url=url,
+                    files=files,
+                    data={"model": model, "seed": seed},
+                    headers=headers
+                )
                 response.raise_for_status()
                 return GatewayTask.model_validate_json(response.text)
             
@@ -75,7 +80,10 @@ class GatewayApi:
             raise GatewayAddTaskError(f"Gateway: error to add task: {e}") from e
         
         finally:
+            try:
                 os.remove(temp_path)
+            except OSError:
+                pass
 
 
     def get_status(self, task_id:str) -> GatewayTaskStatusResponse:
@@ -108,14 +116,21 @@ class GatewayApi:
         return self.GATEWAY_TASK_TIMEOUT_SEC
 
     def _construct_url(self, *, host: str, route: GatewayRoutes, **kwargs: Any) -> str:
-        return f"{host}{route.value}?{urlencode(kwargs)}"
+        query = urlencode(kwargs)
+        if query:
+            return f"{host}{route.value}?{query}"
+        return f"{host}{route.value}"
 
 _gateway_instance = None
 
 
 def get_gateway():
     global _gateway_instance
-    if _gateway_instance is None:
-        prefs = bpy.context.preferences.addons["bl_ext.user_default.fourofour_3d_gen"].preferences
+    prefs = bpy.context.preferences.addons["bl_ext.user_default.fourofour_3d_gen"].preferences
+    if (
+        _gateway_instance is None
+        or _gateway_instance._gateway_url != prefs.url
+        or _gateway_instance._gateway_api_key != prefs.token
+    ):
         _gateway_instance = GatewayApi(prefs.url, prefs.token)
     return _gateway_instance

--- a/fourofour_3d_gen/gateway/gateway_api.py
+++ b/fourofour_3d_gen/gateway/gateway_api.py
@@ -38,7 +38,12 @@ class GatewayApi:
         self._gateway_url = gateway_url
         self._gateway_api_key = gateway_api_key
 
-    
+    def _format_add_task_error(self, error: Exception) -> str:
+        if isinstance(error, requests.HTTPError):
+            response = error.response
+            if response is not None and response.status_code == 429:
+                return "Gateway: too many requests. Please retry later."
+        return f"Gateway: error to add task: {error}"
 
     def add_text_task(self, text_prompt: str, obj_type:str, seed:int) -> GatewayTask:
         """Adds a text task to the gateway."""
@@ -52,7 +57,7 @@ class GatewayApi:
             response.raise_for_status()
             return GatewayTask.model_validate_json(response.text)
         except Exception as e:
-            raise GatewayAddTaskError(f"Gateway: error to add task: {e}") from e
+            raise GatewayAddTaskError(self._format_add_task_error(e)) from e
         
     def add_image_task(self, image, obj_type:str, seed:int) -> GatewayTask:
         """Adds a image task to the gateway."""
@@ -77,7 +82,7 @@ class GatewayApi:
                 return GatewayTask.model_validate_json(response.text)
             
         except Exception as e:
-            raise GatewayAddTaskError(f"Gateway: error to add task: {e}") from e
+            raise GatewayAddTaskError(self._format_add_task_error(e)) from e
         
         finally:
             try:

--- a/fourofour_3d_gen/gateway/gateway_task.py
+++ b/fourofour_3d_gen/gateway/gateway_task.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from datetime import datetime
+import re
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 import bpy
 class GatewayTaskStatus(Enum):
     """Status of the task in gateway"""
@@ -18,6 +19,16 @@ class GatewayTaskStatusResponse(BaseModel):
     status: GatewayTaskStatus
     reason: str | None = None
 
+    @field_validator("status", mode="before")
+    @classmethod
+    def _normalize_partial_result(cls, value):
+        if isinstance(value, str):
+            if value == GatewayTaskStatus.PARTIAL_RESULT.value:
+                return value
+            if re.fullmatch(r"PartialResult\(\d+\)", value):
+                return GatewayTaskStatus.PARTIAL_RESULT.value
+        return value
+
 
 class GatewayTask(BaseModel):
     """Task for the gateway"""
@@ -26,5 +37,4 @@ class GatewayTask(BaseModel):
     result: bytes | None = None
     status: GatewayTaskStatus = GatewayTaskStatus.NO_RESULT
     reason: str | None = None
-
 


### PR DESCRIPTION
This PR fixes the following issues:

1. Incorrect number of arguments passed to add_text_task and add_image_task.
2. Jobs never transition to failed when the gateway returns Failure.
3. Temporary file cleanup in add_image_task can mask the original gateway error.
4. The URL builder always appends ? (e.g., /add_task?), even when there are no query parameters, which can be brittle.
5. Handles the gateway's partial status format PartialResult(<n>) in add-on status parsing (avoids false job failures caused by enum parsing errors).
6. Assigns temporary local job IDs before submission, then replaces them with the gateway task ID upon successful submission (fixes restart/remove targeting for pre-submit failures).
7. Stops the job polling timer when no active jobs remain (RUNNING/WAITING), preventing failed-only queues from polling indefinitely.